### PR TITLE
Fixed an issue where the return value of a checkbox was of type strin…

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -692,7 +692,7 @@ export class MODULE {
             return html.find(`input#${i}qd`)[0].value;
           case `radio`:
           case `checkbox`:
-            return html.find(`input#${i}qd`)[0].checked ? html.find(`input#${i}qd`)[0].value : false;
+            return html.find(`input#${i}qd`)[0].checked;
           case `number`:
             return html.find(`input#${i}qd`)[0].valueAsNumber;
         }


### PR DESCRIPTION
…g instead of boolean

The HTML element instance checked attribute is different to the input type="checkbox" checked attribute. The latter specifies default state whereas the former is the current state of the element.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#additional_attributes
https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement